### PR TITLE
Convert to single cluster mode

### DIFF
--- a/config.template.yml
+++ b/config.template.yml
@@ -2,6 +2,8 @@ flask:
   debug: false
   port: 7708
 manager:
-  proxmox.local:
-      username: "username"
-      password: "secret-password"
+  nodes:
+    - proxmox.local
+  ssl_verify: true
+  username: "username"
+  password: "secret-password"

--- a/manager_test.py
+++ b/manager_test.py
@@ -18,34 +18,36 @@ nodes = [
         "uptime": 4195739,
         "maxmem": 201420058624,
         "type": "node",
-        "id": "node/node1"
+        "id": "node/node1",
     }
 ]
 
 qemu = {
-    'node1': [{
-        "vmid": "1",
-        "pid": "5130",
-        "netout": 44539988293,
-        "mem": 1734115988,
-        "template": "",
-        "cpu": 0.0475956802379353,
-        "netin": 47976268606,
-        "disk": 0,
-        "diskread": 0,
-        "status": "running",
-        "name": "vm1.fqdn",
-        "uptime": 1806468,
-        "diskwrite": 0,
-        "maxdisk": 34359738368,
-        "cpus": 1,
-        "maxmem": 2147483648
-    }] 
+    "node1": [
+        {
+            "vmid": "1",
+            "pid": "5130",
+            "netout": 44539988293,
+            "mem": 1734115988,
+            "template": "",
+            "cpu": 0.0475956802379353,
+            "netin": 47976268606,
+            "disk": 0,
+            "diskread": 0,
+            "status": "running",
+            "name": "vm1.fqdn",
+            "uptime": 1806468,
+            "diskwrite": 0,
+            "maxdisk": 34359738368,
+            "cpus": 1,
+            "maxmem": 2147483648,
+        }
+    ]
 }
 
 qemu_config = {
-    'node1': {
-        '1': { # vm1.fqdn
+    "node1": {
+        "1": {  # vm1.fqdn
             "memory": 4096,
             "scsi0": "storage3:1/vm-1-disk-0.qcow2,size=32G",
             "vmgenid": "89e60754-6cf3-4b77-a075-229d25a43101",
@@ -54,7 +56,7 @@ qemu_config = {
             "name": "",
             "boot": "order=scsi0;net0",
             "net0": "vmxnet3=00:00:00:00:00:01,bridge=vmbr0",
-            "smbios1": "uuid=eaa1f69d-efab-46f4-8ae7-a8d1658845fa"
+            "smbios1": "uuid=eaa1f69d-efab-46f4-8ae7-a8d1658845fa",
         }
     }
 }
@@ -62,32 +64,42 @@ qemu_config = {
 
 class TestManager(unittest.TestCase):
     def setUp(self):
-        self.config = {
-            'manager': {
-                'proxmox.local': {}
-            }
-        }
+        self.config = {"manager": {"proxmox.local": {}}}
 
         def node1_get(key):
-            if key != 'qemu':
-                raise Exception('node_get only supports qemu key')
-            return qemu['node1']
+            if key != "qemu":
+                raise Exception("node_get only supports qemu key")
+            return qemu["node1"]
 
         self.proxmox_mock = MagicMock()
         self.proxmox_mock.nodes.get.return_value = nodes
-        self.proxmox_mock.nodes('node1').get = MagicMock(side_effect=node1_get)
-        self.proxmox_mock.nodes('node1').qemu('1').config().get.return_value = qemu_config['node1']['1']
+        self.proxmox_mock.nodes("node1").get = MagicMock(side_effect=node1_get)
+        self.proxmox_mock.nodes("node1").qemu(
+            "1"
+        ).config().get.return_value = qemu_config["node1"]["1"]
 
-    def proxmox_connector(self, server, config):
+    def proxmox_connector(self, config):
         return self.proxmox_mock
 
-    def test_inventories(self):
-        got = manager.inventories(self.config, connector=self.proxmox_connector)
+    def test_inventory(self):
+        got = manager.inventory(self.config, connector=self.proxmox_connector)
         expected = [
-            {'uuid': 'eaa1f69d-efab-46f4-8ae7-a8d1658845fa', 'name': 'vm1.fqdn'}
+            {"uuid": "eaa1f69d-efab-46f4-8ae7-a8d1658845fa", "name": "vm1.fqdn"}
         ]
         self.assertEqual(expected, got)
 
-  
-if __name__ == '__main__':
+    def test_virtual_machine(self):
+        got = manager.virtual_machine(
+            self.config,
+            "eaa1f69d-efab-46f4-8ae7-a8d1658845fa",
+            connector=self.proxmox_connector,
+        )
+        expected = {
+            "uuid": "eaa1f69d-efab-46f4-8ae7-a8d1658845fa",
+            "name": "vm1.fqdn",
+        }
+        self.assertEqual(expected, got)
+
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The manager can only manage a single Proxmox cluster, but can use multiple nodes when interacting with the cluster. Specify all nodes in the cluster, so that the manager can work even if some nodes are down or unavailable.

It should be easy to run multiple instances on different ports for each cluster.